### PR TITLE
Add @jill64/svelte-ogp package and refactor i18n with OGP support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@jill64/sentry-sveltekit-cloudflare": "1.0.0",
     "@jill64/svelte-dark-theme": "1.3.0",
     "@jill64/svelte-i18n": "0.2.3",
+    "@jill64/svelte-ogp": "^0.0.1",
     "@jill64/svelte-toast": "1.0.0",
     "@jill64/tailwind-grid-auto": "1.1.1",
     "@jill64/tailwind-reactions": "1.0.1",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,10 +1,11 @@
 import { PUBLIC_SENTRY_DSN } from '$env/static/public'
-import { attach } from '$lib/i18n'
+import { attach as lang_attach } from '$lib/i18n'
 import { serverInit } from '@jill64/sentry-sveltekit-cloudflare'
 import { onRender } from '@jill64/svelte-dark-theme'
+import { attach as ogp_attach } from '@jill64/svelte-ogp'
 import { sequence } from '@sveltejs/kit/hooks'
 
 const { onHandle, onError } = serverInit(PUBLIC_SENTRY_DSN)
 
-export const handle = onHandle(sequence(attach, onRender()))
+export const handle = onHandle(sequence(lang_attach, onRender(), ogp_attach))
 export const handleError = onError()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { page } from '$app/stores'
   import { translate } from '$lib/i18n'
   import { ThemeManager, theme } from '@jill64/svelte-dark-theme'
   import { LanguageManager, LocaleAlternates } from '@jill64/svelte-i18n'
+  import { OGP } from '@jill64/svelte-ogp'
   import { Toaster } from '@jill64/svelte-toast'
   import '../app.postcss'
 
@@ -24,18 +24,19 @@
 <LanguageManager />
 <LocaleAlternates />
 <ThemeManager />
+<OGP
+  {title}
+  {description}
+  site_name={title}
+  image="https://example.com/og-image.png"
+/>
 <svelte:head>
   <!-- 
     <link rel="icon" href="{base}/favicon{suffix}.png" />
     <link rel="icon" href="{base}/favicon{suffix}.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="{base}/apple-touch-icon{suffix}.png" />
   -->
+  <title>{title}</title>
   <meta name="description" content={description} />
-  <meta property="og:url" content={$page.url.href} />
-  <meta property="og:title" content={title} />
-  <meta property="og:description" content={description} />
-  <meta property="og:site_name" content={title} />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://example.com/og-image.png" />
 </svelte:head>
 <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Svelte App Template</h1>

--- a/src/routes/[locale=locale]/+page.svelte
+++ b/src/routes/[locale=locale]/+page.svelte
@@ -1,1 +1,0 @@
-<h1>Svelte App Template</h1>

--- a/src/routes/[locale=locale]/+page.svelte
+++ b/src/routes/[locale=locale]/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Svelte App Template</h1>

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 
 test('smoke', async ({ page }) => {
   await page.goto('/')
-  
+
   await expect(
     page.getByRole('heading', { name: 'Svelte App Template' })
   ).toBeVisible()

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,5 +1,9 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('smoke', async ({ page }) => {
   await page.goto('/')
+  
+  await expect(
+    page.getByRole('heading', { name: 'Svelte App Template' })
+  ).toBeVisible()
 })


### PR DESCRIPTION
This pull request adds the @jill64/svelte-ogp package to the project and refactors the i18n implementation to include OGP support. Additionally, a heading has been added to the Svelte App Template page and the smoke test has been updated to check for the presence of the heading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Open Graph Protocol (OGP) support for better social media sharing.
	- Added a new heading "Svelte App Template" to the page.
- **Refactor**
	- Updated import statements for better code organization.
- **Tests**
	- Added a new test case to verify the visibility of the new heading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->